### PR TITLE
Add Composer file for easier project inclusion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "humanmade/post-css",
+  "type": "wordpress-plugin",
+  "description": "Enables adding custom CSS for a post",
+  "homepage": "https://humanmade.com",
+  "license": "GPL-2.0+",
+  "version": "1.0.0",
+  "require": {
+    "php": ">=7.0"
+  }
+}

--- a/plugin.php
+++ b/plugin.php
@@ -4,6 +4,7 @@
  * Description: Enables adding custom CSS for a post.
  * Author: Human Made Limited
  * Author URL: https://humanmade.com
+ * Version: 1.0.0
  */
 
 namespace HM\PostCSS;


### PR DESCRIPTION
Having a composer.json file for including in projects will make our lives much easier because we can properly place the library using installer paths.