### PR TITLE
Skip updating custom CSS via action while performing cron

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -76,6 +76,10 @@ function save_post( $post_id, WP_Post $post ) {
 		return;
 	}
 
+	if ( defined( 'DOING_CRON' ) ) {
+		return;
+	}
+
 	$css = filter_input( INPUT_POST, 'hm_post_css', FILTER_SANITIZE_STRING );
 
 	wp_update_custom_css_post( $css, [


### PR DESCRIPTION
The `save_post` action is called during cron when a scheduled posts becomes published. Resolves an issue where a schedule post’s custom CSS is cleared once the post is published.