### PR TITLE
Only running wp_update_custom_css_post() if the contents of the CSS is not empty.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -80,10 +80,11 @@ function save_post( $post_id, WP_Post $post ) {
 		return;
 	}
 
-	$css = filter_input( INPUT_POST, 'hm_post_css', FILTER_SANITIZE_STRING );
+	$new_css     = filter_input( INPUT_POST, 'hm_post_css', FILTER_SANITIZE_STRING );
+	$current_css = wp_get_custom_css( 'hm-post-css-' . $post_id );
 
-	if ( ! empty( $css ) ) {
-		wp_update_custom_css_post( $css, [
+	if ( ! empty( $new_css ) || $new_css !== $current_css ) {
+		wp_update_custom_css_post( $new_css, [
 			'stylesheet' => 'hm-post-css-' . $post_id,
 		] );
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -82,9 +82,11 @@ function save_post( $post_id, WP_Post $post ) {
 
 	$css = filter_input( INPUT_POST, 'hm_post_css', FILTER_SANITIZE_STRING );
 
-	wp_update_custom_css_post( $css, [
-		'stylesheet' => 'hm-post-css-' . $post_id,
-	] );
+	if ( ! empty( $css ) ) {
+		wp_update_custom_css_post( $css, [
+			'stylesheet' => 'hm-post-css-' . $post_id,
+		] );
+	}
 }
 
 add_action( 'save_post', __NAMESPACE__ . '\\save_post', 10, 2 );


### PR DESCRIPTION
This is to prevent warnings about empty post_content

```
WordPress database error Column 'post_content' cannot be null for query INSERT INTO `wp_14_posts` (`post_author`, `post_date`, `post_date_gmt`, `post_content`, `post_content_filtered`, `post_title`, `post_excerpt`, `post_status`, `post_type`, `comment_status`, `ping_status`, `post_password`, `post_name`, `to_ping`, `pinged`, `post_modified`, `post_modified_gmt`, `post_parent`, `menu_order`, `post_mime_type`, `guid`) VALUES (120012101744, '2021-09-13 13:22:06', '2021-09-13 11:22:06', NULL, '', 'hm-post-css-214945', '', 'publish', 'custom_css', 'closed', 'closed', '', 'hm-post-css-214945', '', '', '2021-09-13 13:22:06', '2021-09-13 11:22:06', 0, 0, '', 'urn:uuid:fcec5713-8ca1-4257-bf2e-cb7630be5285') 

Made by shutdown_action_hook
do_action('shutdown'), 
WP_Hook->do_action, 
WP_Hook->apply_filters, 
\ElasticPress\SyncManager->index_sync_queue, 
ElasticPress\Indexable->bulk_index, 
ElasticPress\Indexable\Post\Post->prepare_document,
apply_filters('the_content'), 
WP_Hook->apply_filters, 
WP_Embed->autoembed, 
preg_replace_callback, 
WP_Embed->autoembed_callback, 
WP_Embed->shortcode, 
wp_insert_post, 
do_action('save_post'), 
WP_Hook->do_action, 
WP_Hook->apply_filters, 
HM\PostCSS\save_post, 
wp_update_custom_css_post, 
wp_insert_post, 
wpdb->insert, 
wpdb->_insert_replace_helper, 
Altis\Cloud\DB->query, 
wpdb->print_error
```
